### PR TITLE
Add commands to initialize modes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -45,13 +45,13 @@ public final class Constants {
     /** Constants for the Digital Input/Output ports. */
     public static final class DIO {
       /** The ports of the left drive encoder. */
-      public static final int[] kPortsEncoderDriveLeft = {0, 1, 2, 3};
+      public static final int[] kPortsEncoderDriveLeft = {0, 1};
       /** The ports of the right drive encoder. */
-      public static final int[] kPortsEncoderDriveRight = {4, 5, 6, 7};
+      public static final int[] kPortsEncoderDriveRight = {2, 3};
       /** The port of the photoelectric sensor at the bottom of the storage, where balls enter. */
-      public static final int kPortPhotoelectricSensorEnter = 8;
+      public static final int kPortPhotoelectricSensorEnter = 4;
       /** The port of the photoelectric sensor at the top of the storage, where balls leave. */
-      public static final int kPortPhotoelectricSensorExit = 9;
+      public static final int kPortPhotoelectricSensorExit = 5;
     }
 
     /** Constants for the Analog Input ports. */

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -113,10 +113,9 @@ public class Robot extends TimedRobot {
     // Enable joystick connection warnings.
     DriverStation.getInstance().silenceJoystickConnectionWarning(true);
 
-    // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
-    // continue until interrupted by another command, remove
-    // this line or comment it out.
+    // This makes sure that the autonomous stops running when teleop starts running. If you want the
+    // autonomous to continue until interrupted by another command, remove this line or comment it
+    // out.
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -83,6 +83,9 @@ public class Robot extends TimedRobot {
   public void disabledInit() {
     // Disable joystick connection warnings.
     DriverStation.getInstance().silenceJoystickConnectionWarning(true);
+
+    // Schedule the disabled init command.
+    m_robotContainer.getDisabledInitCommand().schedule();
   }
 
   /** This method is run periodically in disabled mode. */
@@ -92,7 +95,7 @@ public class Robot extends TimedRobot {
   /** This method is run when the robot enters autonomous mode. */
   @Override
   public void autonomousInit() {
-    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
+    m_autonomousCommand = m_robotContainer.getAutoInitCommand();
 
     // Schedule the autonomous command.
     if (m_autonomousCommand != null) {
@@ -117,6 +120,9 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
+
+    // Schedule the teleop init command.
+    m_robotContainer.getTeleopInitCommand().schedule();
   }
 
   /** This method is run periodically in teleoperated mode. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,6 +10,7 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandGroupBase;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
@@ -20,6 +21,9 @@ import frc.robot.Constants.DriverStation;
 import frc.robot.Constants.DrivetrainConstants;
 import frc.robot.Constants.IntakeConstants;
 import frc.robot.Constants.ShooterConstants;
+import frc.robot.commands.AutoInitCommand;
+import frc.robot.commands.DisabledInitCommand;
+import frc.robot.commands.TeleopInitCommand;
 import frc.robot.driverinput.F310Controller;
 import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.IntakeSubsystem;
@@ -36,6 +40,14 @@ public class RobotContainer {
   @Log private final VisionSubsystem m_visionSubsystem = new VisionSubsystem();
 
   // Commands
+
+  private final DisabledInitCommand m_disabledInitCommand =
+      new DisabledInitCommand(m_drivetrainSubsystem);
+  private final AutoInitCommand m_autoInitCommand =
+      new AutoInitCommand(m_drivetrainSubsystem, m_shooterSubsystem);
+  private final TeleopInitCommand m_teleopInitCommand =
+      new TeleopInitCommand(m_drivetrainSubsystem, m_shooterSubsystem);
+  private final PrintCommand m_autoCommand = new PrintCommand("Autonomous is not implemented yet!");
 
   // Driver Input
 
@@ -114,11 +126,40 @@ public class RobotContainer {
   }
 
   /**
-   * Passes an the autonomous command to the Robot class.
+   * Passes the disabled init command to the Robot class.
    *
-   * @return The command to run in autonomous.
+   * @return The command to run.
    */
-  public Command getAutonomousCommand() {
-    return new PrintCommand("Autonomous is not implemented yet!");
+  public Command getDisabledInitCommand() {
+    return m_disabledInitCommand;
+  }
+
+  /**
+   * Passes the autonomous init command to the Robot class.
+   *
+   * @return The command to run.
+   */
+  public Command getAutoInitCommand() {
+    // Get the current autonomous command. This may be obtained from a SendableChooser.
+    Command autoCommand = m_autoCommand;
+
+    // WPILibJ keeps track of every command that gets added to a group, adding them to a blacklist.
+    // If you try scheduling, or creating another group with a blacklisted command, an exception is
+    // thrown. Since we know that, in Robot.java, there won't be more than one init method running
+    // at once, we can safely assume that this won't result in any weirdness with different
+    // instances of these getting interleaved.
+    CommandGroupBase.clearGroupedCommand(m_autoInitCommand);
+    CommandGroupBase.clearGroupedCommand(autoCommand);
+
+    return m_autoInitCommand.andThen(autoCommand);
+  }
+
+  /**
+   * Passes the teleop init command to the Robot class.
+   *
+   * @return The command to run.
+   */
+  public Command getTeleopInitCommand() {
+    return m_teleopInitCommand;
   }
 }

--- a/src/main/java/frc/robot/commands/AutoInitCommand.java
+++ b/src/main/java/frc/robot/commands/AutoInitCommand.java
@@ -1,0 +1,37 @@
+// Copyright (c) Team 564.
+// Open Source Software; you can modify and/or share it under the terms of
+// the BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+
+import frc.robot.subsystems.DrivetrainSubsystem;
+import frc.robot.subsystems.ShooterSubsystem;
+
+/** Initializes the robot subsystems for autonomous mode. */
+public class AutoInitCommand extends InstantCommand {
+  // Subsystems
+
+  private final DrivetrainSubsystem m_drivetrainSubsystem;
+  private final ShooterSubsystem m_shooterSubsystem;
+
+  /** Initializes this command. */
+  public AutoInitCommand(
+      DrivetrainSubsystem drivetrainSubsystem, ShooterSubsystem shooterSubsystem) {
+    m_drivetrainSubsystem = drivetrainSubsystem;
+    m_shooterSubsystem = shooterSubsystem;
+  }
+
+  /** This method is run when the command is executed. */
+  @Override
+  public void execute() {
+    // Set the neutral mode of the drive motors to break, to prevent coasting in autonomous.
+    m_drivetrainSubsystem.setNeutralMode(NeutralMode.Brake);
+
+    // Reset the double solenoid.
+    m_shooterSubsystem.resetSolenoid();
+  }
+}

--- a/src/main/java/frc/robot/commands/DisabledInitCommand.java
+++ b/src/main/java/frc/robot/commands/DisabledInitCommand.java
@@ -1,0 +1,40 @@
+// Copyright (c) Team 564.
+// Open Source Software; you can modify and/or share it under the terms of
+// the BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+/** Initializes the robot subsystems for disabled mode. */
+public class DisabledInitCommand extends InstantCommand {
+  // Subsystems
+
+  private final DrivetrainSubsystem m_drivetrainSubsystem;
+
+  /** Initializes this command. */
+  public DisabledInitCommand(DrivetrainSubsystem drivetrainSubsystem) {
+    m_drivetrainSubsystem = drivetrainSubsystem;
+  }
+
+  /** This method is run when the command is executed. */
+  @Override
+  public void execute() {
+    // Set the neutral mode of the drive motors to coast.
+    m_drivetrainSubsystem.setNeutralMode(NeutralMode.Coast);
+  }
+
+  /**
+   * Whether the given command should run when the robot is disabled.
+   *
+   * @return Whether the command should run when the robot is disabled.
+   */
+  @Override
+  public boolean runsWhenDisabled() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/TeleopInitCommand.java
+++ b/src/main/java/frc/robot/commands/TeleopInitCommand.java
@@ -1,0 +1,37 @@
+// Copyright (c) Team 564.
+// Open Source Software; you can modify and/or share it under the terms of
+// the BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+
+import frc.robot.subsystems.DrivetrainSubsystem;
+import frc.robot.subsystems.ShooterSubsystem;
+
+/** Initializes the robot subsystems for teleoperated mode. */
+public class TeleopInitCommand extends InstantCommand {
+  // Subsystems
+
+  private final DrivetrainSubsystem m_drivetrainSubsystem;
+  private final ShooterSubsystem m_shooterSubsystem;
+
+  /** Initializes this command. */
+  public TeleopInitCommand(
+      DrivetrainSubsystem drivetrainSubsystem, ShooterSubsystem shooterSubsystem) {
+    m_drivetrainSubsystem = drivetrainSubsystem;
+    m_shooterSubsystem = shooterSubsystem;
+  }
+
+  /** This method is run when the command is executed. */
+  @Override
+  public void execute() {
+    // Set the neutral mode of the drive motors to break, for more responsiveness.
+    m_drivetrainSubsystem.setNeutralMode(NeutralMode.Brake);
+
+    // Reset the double solenoid.
+    m_shooterSubsystem.resetSolenoid();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -43,29 +43,13 @@ public class DrivetrainSubsystem extends SubsystemBase implements Loggable {
 
   @Log(name = "Left Encoder (Relative)", width = 2, height = 1, rowIndex = 0, columnIndex = 3)
   private final Encoder m_encoderRelativeLeft =
-      new Encoder(
-          RoboRIO.DIO.kPortsEncoderDriveLeft[0],
-          RoboRIO.DIO.kPortsEncoderDriveLeft[1],
-          RoboRIO.DIO.kPortsEncoderDriveLeft[2]);
+      new Encoder(RoboRIO.DIO.kPortsEncoderDriveLeft[0], RoboRIO.DIO.kPortsEncoderDriveLeft[1]);
 
-  @Log(name = "Right Encoder (Relative)", width = 2, height = 1, rowIndex = 0, columnIndex = 5)
+  @Log(name = "Right Encoder (Relative)", width = 2, height = 1, rowIndex = 1, columnIndex = 3)
   // This encoder must be reversed so that values will be consistent with the left drive encoder.
   private final Encoder m_encoderRelativeRight =
       new Encoder(
-          RoboRIO.DIO.kPortsEncoderDriveRight[0],
-          RoboRIO.DIO.kPortsEncoderDriveRight[1],
-          RoboRIO.DIO.kPortsEncoderDriveRight[2],
-          true);
-
-  // Duty Cycle Encoders (Measures absolute distance)
-
-  @Log(name = "Left Encoder (Absolute)", width = 2, height = 2, rowIndex = 1, columnIndex = 3)
-  private final DutyCycleEncoder m_encoderAbsoluteLeft =
-      new DutyCycleEncoder(RoboRIO.DIO.kPortsEncoderDriveLeft[3]);
-
-  @Log(name = "Right Encoder (Absolute)", width = 2, height = 2, rowIndex = 1, columnIndex = 5)
-  private final DutyCycleEncoder m_encoderAbsoluteRight =
-      new DutyCycleEncoder(RoboRIO.DIO.kPortsEncoderDriveRight[3]);
+          RoboRIO.DIO.kPortsEncoderDriveRight[0], RoboRIO.DIO.kPortsEncoderDriveRight[1], true);
 
   // Gyroscope
   @Log(name = "Gyroscope", width = 2, height = 2, rowIndex = 0, columnIndex = 7)

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import io.github.oblarg.oblog.Loggable;
 import io.github.oblarg.oblog.annotations.Log;
 
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
 
@@ -69,11 +70,28 @@ public class DrivetrainSubsystem extends SubsystemBase implements Loggable {
 
   /** Initializes the drivetrain subsystem. */
   public DrivetrainSubsystem() {
+    // Revert all motor controller configurations to their factory default values.
+    m_motorFrontLeft.configFactoryDefault();
+    m_motorFrontRight.configFactoryDefault();
+    m_motorBackLeft.configFactoryDefault();
+    m_motorBackRight.configFactoryDefault();
+
     // Make the back motors follow the front motors.
     m_motorBackLeft.follow(m_motorFrontLeft);
     m_motorBackRight.follow(m_motorFrontRight);
   }
 
+  /**
+   * Sets the neutral mode of the drive motors.
+   *
+   * @param mode The neutral mode.
+   */
+  public void setNeutralMode(NeutralMode mode) {
+    m_motorFrontLeft.setNeutralMode(mode);
+    m_motorFrontRight.setNeutralMode(mode);
+    m_motorBackLeft.setNeutralMode(mode);
+    m_motorBackRight.setNeutralMode(mode);
+  }
   /**
    * Drives the robot using arcade drive.
    *

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -52,8 +52,8 @@ public class DrivetrainSubsystem extends SubsystemBase implements Loggable {
           RoboRIO.DIO.kPortsEncoderDriveRight[0], RoboRIO.DIO.kPortsEncoderDriveRight[1], true);
 
   // Gyroscope
-  @Log(name = "Gyroscope", width = 2, height = 2, rowIndex = 0, columnIndex = 7)
-  private final Gyro m_gyro = new ADXRS450_Gyro(SPI.Port.kMXP);
+  @Log(name = "Gyroscope", width = 2, height = 3, rowIndex = 0, columnIndex = 5)
+  private final Gyro m_gyro = new ADXRS450_Gyro();
 
   @Log(name = "Drive", width = 2, height = 3, rowIndex = 0, columnIndex = 0)
   @Log(

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -5,9 +5,7 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
-import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.Encoder;
-import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -38,17 +38,7 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
 
   // Solenoids
 
-  // We can't log this as-is because it is added to Shuffleboard as a Sendable which is an actuator.
-  // Actuator widgets can be used to set the value of the hardware they control, when LiveWindow
-  // is enabled - so, in test mode. As a safety feature, whenever we change to a mode other than
-  // test mode, every actuator is reset to a "safe" value in order to ensure that there won't be
-  // a bad situation created by values that were set in test mode. Unfortunately, even though we
-  // don't use test mode, these safety checks will still run when changing modes.
-  //
-  // Ultimately, the result of this is that, if we add the double solenoid as a Sendable, it will
-  // be subject to safety checks, and, when entering teleoperated mode, get set to the kOff state.
-  // This will prevent the toggle method from working properly. Rather then logging the solenoid
-  // object, we log getSolenoidValue().
+  @Log
   private final DoubleSolenoid m_doubleSolenoidShooter =
       new DoubleSolenoid(
           RoboRIO.CAN.kPortsDoubleSolenoidLauncherCannon[0],
@@ -58,8 +48,13 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
   public ShooterSubsystem() {
     // Make the right motor follow the left.
     m_motorShooterRight.follow(m_motorShooterLeft);
+  }
 
-    // Initialize the position of the double solenoid.
+  /**
+   * Resets the position of the double solenoid. This is nice to have because exiting test mode
+   * resets the solenoid to kOff, which breaks toggle().
+   */
+  public void resetSolenoid() {
     m_doubleSolenoidShooter.set(DoubleSolenoid.Value.kReverse);
   }
 
@@ -80,15 +75,5 @@ public class ShooterSubsystem extends SubsystemBase implements Loggable {
   /** Toggles the double solenoids to raise or retract the shooter. */
   public void toggleSolenoid() {
     m_doubleSolenoidShooter.toggle();
-  }
-
-  /**
-   * Gets the value of the double solenoid as a string, rather than the Value enum.
-   *
-   * @return The name of the enum value corresponding to the solenoid state.
-   */
-  @Log(name = "Shooter Solenoid", width = 2, height = 1, rowIndex = 1, columnIndex = 0)
-  private String getSolenoidValue() {
-    return m_doubleSolenoidShooter.get().name();
   }
 }


### PR DESCRIPTION
Surprise, here's another PR :)

This PR gets rid of unused encoders, and implements a fix for #9. It ended up not being super complicated, so I think this is how we'll work with initializing things after the robot has booted from now on. More information is in the commit messages.